### PR TITLE
Replace email link to <address> format

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 ## Contributing to epiverse-trace packages
-There are lots of ways you can contribute to packages within the epiverse-trace organisation. All contributions are most welcome and only some of these require techical knowledge. If you have something to contribute but aren't sure how, please don't hesitate to log an issue or get in touch with Community Manager Anna by [email](anna.carnegie@lshtm.ac.uk). 
+There are lots of ways you can contribute to packages within the epiverse-trace organisation. All contributions are most welcome and only some of these require techical knowledge. If you have something to contribute but aren't sure how, please don't hesitate to log an issue or get in touch with Community Manager Anna by email to <anna.carnegie@lshtm.ac.uk>. 
 
 The below guidelines outline how to propose a change to epiverse-trace packages. We abide by the contibuting guidelines developed by the tidyverse. For more detailed info about contributing to this, and other epiverse-trace packages, please see the [tidyverse development contributing guide](https://www.tidyverse.org/contribute/). 
 


### PR DESCRIPTION
The `<address>` format redirect the link to the "mailto:", instead of a dead end of the current format.

For direct comparison:
- by [email](anna.carnegie@lshtm.ac.uk)
- by email to <anna.carnegie@lshtm.ac.uk>
