### PR TITLE
Exclude R/RcppExports.R from package linting

### DIFF
--- a/workflows/lint-changed-files.yaml
+++ b/workflows/lint-changed-files.yaml
@@ -40,7 +40,7 @@ jobs:
           files <- gh::gh("/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files")
           changed_files <- purrr::map_chr(files, "filename")
           all_files <- list.files(recursive = TRUE)
-          exclusions_list <- as.list(setdiff(all_files, changed_files))
+          exclusions_list <- as.list(c(setdiff(all_files, changed_files), "R/RcppExports.R"))
           lintr::lint_package(exclusions = exclusions_list)
         shell: Rscript {0}
         env:


### PR DESCRIPTION
This PR aims to fix #17.