### PR TITLE
Import codes of conduct from Google Docs

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,2 +1,2 @@
-- [Epiverse-TRACE Community Code of Conduct in English](https://docs.google.com/document/u/1/d/e/2PACX-1vRcwl2uaKdEQT5iS-9MroDMKsd81oR8v1gdlY1kHTTjgGEbLKfcWxtdrkvVRhJJGQalsgC1A4K4YiDe/pub)
-- [Código de conducta de la comunidad Epiverse-TRACE en Español](https://docs.google.com/document/d/e/2PACX-1vSi9qlNRvh6nSSlHEcM8mpB9XQHDQyo2I12VG--r5SwciJ5UdRzhUp3sYXJhXoyYg/pub)
+- [Epiverse-TRACE Community Code of Conduct in English](./CODE_OF_CONDUCT_en.md)
+- [Código de conducta de la comunidad Epiverse-TRACE en Español](./CODE_OF_CONDUCT_es.md)

--- a/CODE_OF_CONDUCT_en.md
+++ b/CODE_OF_CONDUCT_en.md
@@ -1,0 +1,76 @@
+# Epiverse-TRACE Community code of conduct
+
+## Overview
+
+Epiverse-TRACE is a global community of members who align around a shared vision of improving the outbreak analytics landscape through the development of scalable, open-source, community-driven software tools. Our community is the heart of the Epiverse initiative. Each and every community member plays a valuable role in our collective success.
+
+We respect the individual identities of our members and we are dedicated to making our spaces accessible, inclusive, and welcoming for all. Our intention is to create spaces where members feel encouraged to contribute safely and to ask questions without fear of judgement or disrespect. We take action against unacceptable forms of behaviour. No one's reputation is more important than the safety of our community members.  
+
+We are conscious of the power imbalances which exist within these and all group spaces. We strive to actively recognise said imbalances and to minimise their harmful effects.
+
+We will not always get it right and we encourage members of the community to reach out and let us know in cases where we miss the mark. We are committed to learning from one another and growing together.
+
+This code of conduct is a living document which is intended to evolve in line with feedback from members of the community. We welcome your input on any element of it. Please do reach out to our Community Manager Anna if you have any thoughts and/or suggestions: [anna.carnegie@lshtm.ac.uk](mailto:anna.carnegie@lshtm.ac.uk) 
+
+## Where and when the code of conduct applies
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing Epiverse-TRACE.
+
+Examples of representing our community include using an official email address, posting via an official social media account, acting as an appointed representative at an online or offline event (such as workshops, panel discussions and training activities).
+
+Individuals participating in Epiverse-TRACE events (whether as a trainer, panellist or participant) will be required to adhere to the Code of Conduct upon registering to attend the event.
+
+## Our standards
+
+Examples of behaviour which contribute to a welcoming environment for the community include:
+
+* Remembering that people live lives and navigate challenges beyond the confines of the community. Practicing empathy, kindness and respect, always.
+* Assuming good intentions and asking for clarification where there is any uncertainty.
+* Being respectful and non-judgemental towards differing experiences or points of view.
+* Recognising that everyone's contributions can be valid, independent of title, skill-level or knowledge base.  
+* Giving and receiving feedback in a constructive and gracious fashion.
+* Reflecting on the impact of our words and actions on others within the community.
+* Accepting responsibility for our mistakes, apologising to those affected, learning from the experience and adjusting our behaviour accordingly.
+* Expressing gratitude where we have been supported by the actions, expertise or resources of others.
+
+## Unacceptable forms of behavior
+
+Examples of behaviours which are not welcome in our community include (but are not limited to):
+
+* Unwelcome sexual attention or physical contact.
+* Personal attacks, including derogatory comments, insulting, ignoring, shaming or belittling others.
+* Public or private harassment.
+* Publishing others' private information without their express permission.
+* Other conduct which could reasonably be considered inappropriate in a professional setting.
+
+## Enforcement
+
+The Community Manager and members of the Epiverse-TRACE team are responsible for clarifying and enforcing our standards of acceptable behaviour and will take appropriate and fair corrective action in response to any behaviour that they deem inappropriate, threatening, offensive, or harmful.
+
+The Community Manager and members of the Epiverse-TRACE team have the right and responsibility to remove, edit, or reject comments, commits, code, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+The Code of Conduct Committee will determine appropriate enforcement measures on a case-by-case basis. Where practicable, violations to this code of conduct will be addressed informally in the first instance. For example through a verbal or written warning. Repeated or serious violations may result in more sustained ramifications, including a temporary or permanent ban from community spaces (e.g. forums, events) and, where necessary, the involvement of law authorities.
+
+## Reporting
+
+Incidents can be reported to the Epiverse-TRACE Code of Conduct Committee through completing this short form:  <https://forms.gle/guKqVXPk6K43jPn59>
+
+Current membership of the Committee is:
+
+* Anna Carnegie, Community Manager - LSHTM
+* Diana Fajardo Pulido, Research Coordinator TRACE-LAC - Pontificia Universidad Javeriana
+* Nicolas Yanez, Clinical Data Scientist - Philips Research North America [external Committee Member]
+* Mauricio Santos Vega, Research Professor - Universidad de los Andes
+* Claudine Lim, Program Manager - data.org
+
+You may also make a report directly to one member of the Committee by contacting them directly. If any member of the Committee has a conflict of interest with a report, they will be recused and will not have access to the content or process of the report follow-up, which will be handled by the other members of the Committee.
+
+Upon submitting your report, you will receive a copy of your responses via email. You should receive a separate acknowledgement of receipt via email from the Code of Conduct Committee within 48 hours on weekdays, or within 72 hours for an event that takes place on a weekend.
+
+The Committee will investigate your report and follow up according to our Code of Conduct with the aim of making a decision and implementing enforcement as soon as is reasonably possible.
+
+If you would like to report an incident independent of the Epiverse-TRACE reporting mechanism, you can do so using LSHTM's [Report and Support tool](https://reportandsupport.lshtm.ac.uk/), where your concern will be triaged by a member of LSHTM's Equity and Diversity Team.
+
+## Attribution
+
+This code of conduct was inspired by the codes and guidelines developed by our colleagues [ROpenSci](https://ropensci.org/code-of-conduct/), [RECON](https://www.repidemicsconsortium.org/CODE_OF_CONDUCT/) and the [CSCCE](https://www.cscce.org/cscce-community-participation-guidelines/). The reporting form was inspired by that developed by ROpenSci. We are indebted to them for this.

--- a/CODE_OF_CONDUCT_es.md
+++ b/CODE_OF_CONDUCT_es.md
@@ -1,0 +1,76 @@
+# Epiverse-TRACE Código de conducta de la comunidad
+
+## Visión general
+
+Epiverse-TRACE es una comunidad global de miembros que se alinean alrededor de una visión compartida para mejorar el panorama de análisis de brotes a través del desarrollo de herramientas de software escalables, de código abierto, e impulsadas por la comunidad. Nuestra comunidad es el núcleo de la iniciativa Epiverse. Todos y cada uno de los miembros tienen un rol valioso en nuestro éxito colectivo.
+
+Respetamos las identidades individuales de nuestros miembros y estamos dedicados a hacer que nuestros espacios sean accesibles, inclusivos, y acogedores para todos. Nuestra intención es crear espacios donde los miembros se sientan alentados a contribuir de manera segura y a hacer preguntas sin miedo a juicios de valor o faltas de respeto. Tomamos medidas contracomportamientos inaceptables. La reputación de nadie es más importante que la seguridad de los miembros de nuestra comunidad.
+
+Somos conscientes de los desequilibrios de poder que existen dentro de estos y todos los espacios grupales. Nos esforzamos por reconocer activamente dichos desequilibrios y minimizar sus efectos nocivos.
+
+No siempre lo haremos bien e incitamoss a los miembros de la comunidad a comunicarse y avisarnos en los casos en que no acertamos. Estamos comprometidos a aprender unos de otros y crecer juntos.
+
+Este código de conducta es un documento vivo destinado a evolucionar con la retroalimentación de los miembros de la comunidad. Damos la bienvenida a su aporte a cualquier momento. Por favor, comuníquese con Anna, nuestra administradora de la comunidad, si tiene alguna idea o sugerencia: [anna.carnegie@lshtm.ac.uk](mailto:anna.carnegie@lshtm.ac.uk)
+
+## Dónde y cuándo se aplica el código de conducta
+
+Este código de conducta se aplica dentro de todos los espacios comunitarios, y también cuando una persona representa oficialmente a Epiverse-TRACE.
+
+Ejemplos de representar a nuestra comunidad incluyen usar una dirección de correo electrónico oficial, publicar a través de una cuenta oficial de redes sociales, actuar como representante designado en un evento virtual o en persona (como talleres, paneles de discusión, y capacitaciones).
+
+Las personas que participen en eventos de Epiverse-TRACE (ya sea como capacitadores, panelistas, o participantes) deberán cumplir con el código de conducta al registrarse para asistir al evento.
+
+## Nuestros estándares
+
+Ejemplos de comportamiento que contribuyen a un ambiente acogedor para la comunidad incluyen:
+
+* Recordar que las personas tienen vida y enfrentan desafíos más allá de los límites de la comunidad.Practicar siempre la empatía, la amabilidad, y el respeto.
+* Asumir que las intenciones son buenas y pedir aclaraciones cuando exista alguna incertidumbre.
+* Ser respetuoso y no juzgar las experiencias o puntos de vista diferentes de los demás.
+* Reconocer que las contribuciones de todos pueden ser válidas, independientemente del título, el nivel de habilidad, o la base de conocimientos.
+* Dar y recibir comentarios de manera constructiva y cortés.
+* Reflexionar sobre el impacto de nuestras palabras y acciones en otros miembros dentro de la comunidad.
+* Aceptar la responsabilidad de nuestros errores, pedir disculpasalos afectados, aprender de la experiencia y ajustar nuestro comportamiento como corresponde.
+* Expresar gratitud cuando hemos sido apoyados por las acciones, la habilidad, o los recursos de otros.
+
+## Formas inaceptables de comportamiento
+
+Ejemplos de comportamientos que no son bienvenidos en nuestra comunidad incluyen (pero no se limitan a):
+
+* Atención sexual o contacto físico no deseado.
+* Ataques personales, incluyendo comentarios despectivos, insultos, ignorar, avergonzar o menospreciar a otros.
+* Acoso público o privado.
+* Publicar información privada de otros sin su permiso expreso.
+* Otras conductas que razonablemente podrían considerarse inapropiadas en un entorno profesional.
+
+## Cumplimiento del código
+
+La administradora de la comunidad y los miembros del equipo Epiverse-TRACE son responsables de aclarar y hacer cumplir nuestros estándares de comportamiento aceptable y tomarán medidas correctivas apropiadas y justas en respuesta a cualquier comportamiento que consideren inapropiado, amenazante, ofensivo, o dañino.
+
+La administradora de la comunidad y los miembros del equipo Epiverse-TRACE tienen el derecho y la responsabilidad de eliminar, editar, o rechazar comentarios, compromisos, códigos, y otras contribuciones que no estén alineadas con este código de conducta, y comunicarán los motivos de sus decisiones cuando sea adecuado.
+
+El código de conducta determinará las medidas de cumplimiento apropiadas caso por caso. Cuando sea factible, las violaciones a este código de conducta se abordarán informalmente en primera instancia. Por ejemplo, a través de una advertencia verbal o escrita. Las infracciones repetidas o graves pueden dar lugar a ramificaciones más sostenidas, incluida la prohibición temporal o permanente al acceso de los espacios comunitarios (por ejemplo, foros o eventos) y, cuando sea necesario, la intervención de autoridades legales.
+
+## Reportes
+
+Los incidentes se pueden reportar al comité del código de conducta de Epiverse-TRACE completando este breve formulario: <https://forms.gle/WG63ZsudUjEXVMzP7>
+
+La composición actual del comité es:
+
+* Anna Carnegie, administradora de la comunidad - LSHTM
+* Diana Fajardo Pulido, coordinadora de investigación TRACE-LAC - Pontificia Universidad Javeriana
+* Nicolas Yanez, Científico de Datos Clínicos - Philips Research North America [miembro externo del comité]
+* Mauricio Santos Vega, profesor de investigación - Universidad de los Andes
+* Claudine Lim, directora del programa - data.org
+
+También puede presentar un informe a un miembro del comité poniéndose en contacto directamente. Si algún miembro del comité tiene conflicto de interés con un informe, será recusado y no tendrá acceso al contenido o proceso de seguimiento del informe, el cual será manejado por los demás miembros del comité.
+
+Al enviar su informe, recibirá por correo electrónico una copia de sus respuestas. Dentro de las 48 horas siguientes en días hábiles o 72 horas en fines de semana, recibirá por correo electrónico un acuse de recibido.
+
+El comité investigará su informe y hará un seguimiento de acuerdo con nuestro código de conducta con el objetivo de tomar una decisión e implementar medidas adecuadas tan pronto como sea posible.
+
+Si desea informar un incidente independientemente del mecanismo de informe de Epiverse-TRACE, puede hacerlo utilizando la [herramienta de reporte y soporte](https://reportandsupport.lshtm.ac.uk/) de LSHTM donde su caso será evaluado por un miembro del equipo de Equidad y Diversidad de LSHTM.
+
+## Atribución
+
+Este código de conducta se inspiró en los códigos y lineamientos desarrollados por nuestros colegas en [ROpenSci](https://ropensci.org/code-of-conduct/), [RECON](https://www.repidemicsconsortium.org/CODE_OF_CONDUCT/) y [CSCCE](https://www.cscce.org/cscce-community-participation-guidelines/). El formulario de informes se inspiró en el desarrollado por ROpenSci. Estamos agradecidos con ellos por esto.


### PR DESCRIPTION
This PR imports the codes of conduct (English and Spanish) into the repository directly. It also adds relative links to the files from the general code of conduct, as discussed in #26.

This PR does not review the content of the codes of conduct, which I will open a separate issue for. 

If merged, fixes #26.