### PR TITLE
Remove code of conduct form and add note

### DIFF
--- a/CODE_OF_CONDUCT_en.md
+++ b/CODE_OF_CONDUCT_en.md
@@ -53,7 +53,10 @@ The Code of Conduct Committee will determine appropriate enforcement measures on
 
 ## Reporting
 
-Incidents can be reported to the Epiverse-TRACE Code of Conduct Committee through completing this short form:  <https://forms.gle/guKqVXPk6K43jPn59>
+> [!CAUTION]
+> Due to high turnover of the team, the information below is out of date and currently being revised.
+
+Incidents can be reported to the Epiverse-TRACE Code of Conduct Committee: <dc.fajardop@javeriana.edu.co>
 
 Current membership of the Committee is:
 

--- a/CODE_OF_CONDUCT_es.md
+++ b/CODE_OF_CONDUCT_es.md
@@ -53,7 +53,10 @@ El código de conducta determinará las medidas de cumplimiento apropiadas caso 
 
 ## Reportes
 
-Los incidentes se pueden reportar al comité del código de conducta de Epiverse-TRACE completando este breve formulario: <https://forms.gle/WG63ZsudUjEXVMzP7>
+> [!CAUTION]
+> Debido a la alta rotación del equipo, la siguiente información está desactualizada y actualmente se está revisando.
+
+Los incidentes se pueden reportar al comité del código de conducta de Epiverse-TRACE: <dc.fajardop@javeriana.edu.co>
 
 La composición actual del comité es:
 


### PR DESCRIPTION
This PR removes the google form and adds a cautionary note that the information is outdated. Now it directly points to the email of the remaining project internal committee member.