### PR TITLE
Update workflow to commit to protected branch

### DIFF
--- a/.github/workflows/herdstat.yaml
+++ b/.github/workflows/herdstat.yaml
@@ -19,15 +19,10 @@ jobs:
       - uses: herdstat/herdstat-action@v0.9.1
         env:
           GITHUB_TOKEN: ${{ secrets.ET_HERDSTAT_PAT }}
-      - uses: peter-evans/create-pull-request@10db75894f6d53fc01c3bb0995e95bd03e583a62
-        id: cpr
+      - uses: EndBug/add-and-commit@v9
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: Update `contribution_graph.svg`
-          committer: epiverse-trace-bot <epiverse-trace-bot@users.noreply.github.com>
-          author: epiverse-trace-bot <epiverse-trace-bot@users.noreply.github.com>
-          branch: update-herdstat
-          add-paths: 'contribution-graph.svg'
-          title: Automated update of contribution graph
-          reviewers: chartgerink
-          delete-branch: true  
+          author_name: epiverse-trace-bot
+          author_email: epiverse-trace-bot@users.noreply.github.com
+          message: "Update `contribution_graph.svg`"
+          add: 'contribution-graph.svg'
+          token: ${{ secrets.SUDO_GITHUB_TOKEN }}

--- a/.github/workflows/herdstat.yaml
+++ b/.github/workflows/herdstat.yaml
@@ -9,8 +9,8 @@ name: 'Herdstat Analysis'
 on:
   workflow_dispatch:
   schedule:
-    # Runs every Monday at midnight
-    - cron: '0 0 * * 1'
+    # Runs every day at midnight
+    - cron: '0 0 * * *'
 jobs:
   herdstat:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR uses the newly created Personal Access Token (PAT) `SUDO_GITHUB_TOKEN` to override the branch protection when updating the herdstat contribution graph. We replace the pull request action with a direct commit action.

This helps reduce the unnecessary pull request load. The PAT is accessible in the actions of `.github` and the website repository only.